### PR TITLE
Observe func was not exported, but called remotely. Fixed export

### DIFF
--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -56,7 +56,7 @@ func NewWatcher() (*Watcher, error) {
 	w.watched = make(map[string][]interface{})
 	w.watchers = make([]string, 0)
 	w.dirs = make([]string, 0)
-	go w.observe()
+	go w.Observe()
 
 	return w, nil
 }
@@ -236,7 +236,7 @@ func (w *Watcher) removeDir(name string) {
 
 // Observe dispatches notifications received by the watcher. This function will
 // return when the watcher is closed.
-func (w *Watcher) observe() {
+func (w *Watcher) Observe() {
 	for {
 		select {
 		case ev, ok := <-w.fsEvent:


### PR DESCRIPTION
The function Observe was written as a lower-case "observe" which marks it as private to the struct, however, it was called remotely.
