### PR TITLE
Pull out the clipboard wrapper

### DIFF
--- a/clipboard/clipboard.go
+++ b/clipboard/clipboard.go
@@ -1,0 +1,63 @@
+// Copyright 2016 The lime Authors.
+// Use of this source code is governed by a 2-clause
+// BSD-style license that can be found in the LICENSE file.
+
+package clipboard
+
+import (
+	"fmt"
+
+	"github.com/limetext/backend/log"
+)
+
+type Clipboard struct {
+	getter     func() (string, error)
+	setter     func(string) error
+	cachedText string
+
+	// autoExpanded tracks whether the contents was created from a single
+	// cursor expanded to a line, by a copy command, for example.
+	autoExpanded bool
+}
+
+func New() *Clipboard {
+	return &Clipboard{
+		getter: func() (string, error) {
+			return "", fmt.Errorf("Getter has not been set")
+		},
+		setter: func(s string) error {
+			return fmt.Errorf("Setter has not been set")
+		},
+	}
+}
+
+func (c *Clipboard) SetGetter(getter func() (string, error)) {
+	c.getter = getter
+}
+
+func (c *Clipboard) SetSetter(setter func(string) error) {
+	c.setter = setter
+}
+
+func (c *Clipboard) Set(text string, autoExpanded bool) {
+	if err := c.setter(text); err != nil {
+		log.Warn("Could not set system clipboard: %v", err)
+	}
+
+	// Keep a local copy in case the system clipboard isn't working.
+	c.cachedText = text
+	c.autoExpanded = autoExpanded
+}
+
+func (c *Clipboard) Get() (text string, autoExpanded bool) {
+	var err error
+
+	if text, err = c.getter(); err != nil {
+		log.Warn("Could not get system clipboard: %v", err)
+		text = c.cachedText
+	}
+
+	autoExpanded = c.autoExpanded
+
+	return
+}

--- a/clipboard/clipboard.go
+++ b/clipboard/clipboard.go
@@ -57,7 +57,9 @@ func (c *Clipboard) Get() (text string, autoExpanded bool) {
 		text = c.cachedText
 	}
 
-	autoExpanded = c.autoExpanded
+	if text == c.cachedText {
+		autoExpanded = c.autoExpanded
+	}
 
 	return
 }

--- a/clipboard/clipboard_test.go
+++ b/clipboard/clipboard_test.go
@@ -1,0 +1,5 @@
+// Copyright 2016 The lime Authors.
+// Use of this source code is governed by a 2-clause
+// BSD-style license that can be found in the LICENSE file.
+
+package clipboard

--- a/editor.go
+++ b/editor.go
@@ -373,12 +373,25 @@ func (e *Editor) RunCommand(name string, args Args) {
 	}
 }
 
-func (e *Editor) SetClipboard(text string, autoExpanded bool) {
-	e.clipboard.Set(text, autoExpanded)
+// Clipboard returns the currently active clipboard.
+func (e *Editor) Clipboard() clipboard.Clipboard {
+	return e.clipboard
 }
 
-func (e *Editor) GetClipboard() (text string, autoExpanded bool) {
-	return e.clipboard.Get()
+// GetClipboard returns the contents of the clipboard. It assumes the text was
+// not captured from an auto-expanded cursor. It exists for Sublime Text API
+// compatibility.
+func (e *Editor) GetClipboard() string {
+	s, _ := e.clipboard.Get()
+
+	return s
+}
+
+// SetClipboard modifies the contents of the clipboard. It assumes the text was
+// not captured from an auto-expanded cursor. It exists for Sublime Text API
+// compatibility.
+func (e *Editor) SetClipboard(s string) {
+	e.clipboard.Set(s, false)
 }
 
 func (e *Editor) handleLog(s string) {

--- a/editor.go
+++ b/editor.go
@@ -11,6 +11,7 @@ import (
 	"runtime/debug"
 	"sync"
 
+	"github.com/limetext/backend/clipboard"
 	"github.com/limetext/backend/keys"
 	"github.com/limetext/backend/log"
 	"github.com/limetext/backend/packages"
@@ -35,9 +36,7 @@ type Editor struct {
 	console          *View
 	frontend         Frontend
 	keyInput         chan (keys.KeyPress)
-	clipboardSetter  func(string) error
-	clipboardGetter  func() (string, error)
-	clipboard        string
+	clipboard        *clipboard.Clipboard
 	defaultSettings  *text.HasSettings
 	platformSettings *text.HasSettings
 	defaultKB        *keys.HasKeyBindings
@@ -72,6 +71,7 @@ func GetEditor() *Editor {
 				scratch: true,
 			},
 			keyInput:         make(chan keys.KeyPress, 32),
+			clipboard:        clipboard.New(),
 			defaultSettings:  new(text.HasSettings),
 			platformSettings: new(text.HasSettings),
 			defaultKB:        new(keys.HasKeyBindings),
@@ -85,13 +85,6 @@ func GetEditor() *Editor {
 		var err error
 		if ed.Watcher, err = watch.NewWatcher(); err != nil {
 			log.Error("Couldn't create watcher: %s", err)
-		}
-
-		ed.clipboardSetter = func(s string) error {
-			return fmt.Errorf("clipboard functions has not been set")
-		}
-		ed.clipboardGetter = func() (string, error) {
-			return "", fmt.Errorf("clipboard functions has not been set")
 		}
 
 		ed.console.Settings().Set("is_widget", true)
@@ -152,8 +145,8 @@ func (e *Editor) Init() {
 }
 
 func (e *Editor) SetClipboardFuncs(setter func(string) error, getter func() (string, error)) {
-	e.clipboardSetter = setter
-	e.clipboardGetter = getter
+	e.clipboard.SetGetter(getter)
+	e.clipboard.SetSetter(setter)
 }
 
 func (e *Editor) loadDefaultKeyBindings(dir string) {
@@ -380,22 +373,12 @@ func (e *Editor) RunCommand(name string, args Args) {
 	}
 }
 
-func (e *Editor) SetClipboard(n string) {
-	if err := e.clipboardSetter(n); err != nil {
-		log.Warn("Could not set clipboard: %v", err)
-	}
-
-	// Keep a local copy in case the system clipboard isn't working
-	e.clipboard = n
+func (e *Editor) SetClipboard(text string, autoExpanded bool) {
+	e.clipboard.Set(text, autoExpanded)
 }
 
-func (e *Editor) GetClipboard() string {
-	n, err := e.clipboardGetter()
-	if err != nil {
-		log.Warn("Could not get clipboard: %v", err)
-		return e.clipboard
-	}
-	return n
+func (e *Editor) GetClipboard() (text string, autoExpanded bool) {
+	return e.clipboard.Get()
 }
 
 func (e *Editor) handleLog(s string) {

--- a/editor.go
+++ b/editor.go
@@ -36,7 +36,7 @@ type Editor struct {
 	console          *View
 	frontend         Frontend
 	keyInput         chan (keys.KeyPress)
-	clipboard        *clipboard.Clipboard
+	clipboard        clipboard.Clipboard
 	defaultSettings  *text.HasSettings
 	platformSettings *text.HasSettings
 	defaultKB        *keys.HasKeyBindings
@@ -71,7 +71,7 @@ func GetEditor() *Editor {
 				scratch: true,
 			},
 			keyInput:         make(chan keys.KeyPress, 32),
-			clipboard:        clipboard.New(),
+			clipboard:        clipboard.NewSystemClipboard(),
 			defaultSettings:  new(text.HasSettings),
 			platformSettings: new(text.HasSettings),
 			defaultKB:        new(keys.HasKeyBindings),
@@ -142,11 +142,6 @@ func (e *Editor) Init() {
 	log.Info("Initializing")
 	OnInit.call()
 	OnPackagesPathAdd.Add(packages.Scan)
-}
-
-func (e *Editor) SetClipboardFuncs(setter func(string) error, getter func() (string, error)) {
-	e.clipboard.SetGetter(getter)
-	e.clipboard.SetSetter(setter)
 }
 
 func (e *Editor) loadDefaultKeyBindings(dir string) {
@@ -376,6 +371,11 @@ func (e *Editor) RunCommand(name string, args Args) {
 // Clipboard returns the currently active clipboard.
 func (e *Editor) Clipboard() clipboard.Clipboard {
 	return e.clipboard
+}
+
+// UseClipboard replaces the existing clipboard with c.
+func (e *Editor) UseClipboard(c clipboard.Clipboard) {
+	e.clipboard = c
 }
 
 // GetClipboard returns the contents of the clipboard. It assumes the text was

--- a/editor_test.go
+++ b/editor_test.go
@@ -108,34 +108,28 @@ func TestSetFrontend(t *testing.T) {
 
 func TestClipboard(t *testing.T) {
 	ed := GetEditor()
+	cb := ed.Clipboard()
+
 	// Put back whatever was already there.
-	clip, ex := ed.GetClipboard()
-	defer ed.SetClipboard(clip, ex)
+	clip, ex := cb.Get()
+	defer cb.Set(clip, ex)
 
 	want := "test0"
-	ed.SetClipboard(want, true)
+	ed.SetClipboard(want)
 
-	got, ex := ed.GetClipboard()
+	got := ed.GetClipboard()
 
 	if got != want {
 		t.Errorf("Expected %q to be on the clipboard, but got %q", want, got)
-	}
-
-	if !ex {
-		t.Errorf("Expected the clipboard to be flagged as auto expanded, but it wasn't")
 	}
 
 	want = "test1"
-	ed.SetClipboard(want, true)
+	ed.SetClipboard(want)
 
-	got, ex = ed.GetClipboard()
+	got = ed.GetClipboard()
 
 	if got != want {
 		t.Errorf("Expected %q to be on the clipboard, but got %q", want, got)
-	}
-
-	if !ex {
-		t.Errorf("Expected the clipboard to be flagged as auto expanded, but it wasn't")
 	}
 }
 

--- a/editor_test.go
+++ b/editor_test.go
@@ -122,7 +122,7 @@ func TestClipboard(t *testing.T) {
 	}
 
 	if !ex {
-		t.Errorf("Expected the clipboard, to be flagged as auto expanded, but it wasn't")
+		t.Errorf("Expected the clipboard to be flagged as auto expanded, but it wasn't")
 	}
 
 	want = "test1"
@@ -135,7 +135,7 @@ func TestClipboard(t *testing.T) {
 	}
 
 	if !ex {
-		t.Errorf("Expected the clipboard, to be flagged as auto expanded, but it wasn't")
+		t.Errorf("Expected the clipboard to be flagged as auto expanded, but it wasn't")
 	}
 }
 

--- a/editor_test.go
+++ b/editor_test.go
@@ -109,19 +109,33 @@ func TestSetFrontend(t *testing.T) {
 func TestClipboard(t *testing.T) {
 	ed := GetEditor()
 	// Put back whatever was already there.
-	clip := ed.GetClipboard()
-	defer ed.SetClipboard(clip)
+	clip, ex := ed.GetClipboard()
+	defer ed.SetClipboard(clip, ex)
 
 	want := "test0"
-	ed.SetClipboard(want)
-	if got := ed.GetClipboard(); got != want {
+	ed.SetClipboard(want, true)
+
+	got, ex := ed.GetClipboard()
+
+	if got != want {
 		t.Errorf("Expected %q to be on the clipboard, but got %q", want, got)
 	}
 
+	if !ex {
+		t.Errorf("Expected the clipboard, to be flagged as auto expanded, but it wasn't")
+	}
+
 	want = "test1"
-	ed.SetClipboard(want)
-	if got := ed.GetClipboard(); got != want {
+	ed.SetClipboard(want, true)
+
+	got, ex = ed.GetClipboard()
+
+	if got != want {
 		t.Errorf("Expected %q to be on the clipboard, but got %q", want, got)
+	}
+
+	if !ex {
+		t.Errorf("Expected the clipboard, to be flagged as auto expanded, but it wasn't")
 	}
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,8 @@
-hash: 5169db475edc07d21cddbb0e8efff6a21a963f646805d1c432c6240ad615ddc0
-updated: 2016-08-16T11:42:54.22984791+01:00
+hash: 74f49b5da1af48f6f8597e68f07a494e5a23c61286edf309d06187fc6a68358f
+updated: 2016-08-21T11:03:09.803539363+01:00
 imports:
+- name: github.com/atotto/clipboard
+  version: bb272b845f1112e10117e3e45ce39f690c0001ad
 - name: github.com/limetext/loaders
   version: master
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,6 @@
 package: github.com/limetext/backend
 import:
+- package: github.com/atotto/clipboard
 - package: github.com/limetext/loaders
 - package: github.com/limetext/log4go
 - package: github.com/limetext/rubex


### PR DESCRIPTION
Also add a flag to track if the current contents was auto-expanded, required for full paste command functionality.

Note this is a breaking change which will stop the commands from working.