### PR TITLE
Fix #118 watcher_test.go fails

### DIFF
--- a/packages/watcher_test.go
+++ b/packages/watcher_test.go
@@ -8,11 +8,12 @@ import (
 	"os"
 	"testing"
 	"time"
+	"strings"
 )
 
 func TestWatchDir(t *testing.T) {
 	pkg := &dummyPackage{path: "testdata/file"}
-	rec := &Record{func(s string) bool { return s == "testdata/file" },
+	rec := &Record{func(s string) bool { return strings.Contains(s, "testdata/file") },
 		func(s string) Package { return pkg }}
 
 	Register(rec)

--- a/packages/watcher_test.go
+++ b/packages/watcher_test.go
@@ -8,22 +8,29 @@ import (
 	"os"
 	"testing"
 	"time"
-	"strings"
+	"path/filepath"
 )
 
 func TestWatchDir(t *testing.T) {
-	pkg := &dummyPackage{path: "testdata/file"}
-	rec := &Record{func(s string) bool { return strings.Contains(s, "testdata/file") },
+	// The backend libraries expect absolute paths
+	TestPath, TestPathErr := filepath.Abs("testdata/file")
+
+	if TestPathErr != nil {
+		t.Fatalf("Couldn't get absolute path for testdata/file: %s", TestPathErr)
+	}
+
+	pkg := &dummyPackage{path: TestPath}
+	rec := &Record{func(s string) bool { return s == TestPath },
 		func(s string) Package { return pkg }}
 
 	Register(rec)
 	defer Unregister(rec)
-	watchDir("testdata")
+	watchDir(filepath.Dir(TestPath))
 
-	if _, err := os.Create("testdata/file"); err != nil {
-		t.Fatalf("Error creating 'testdata/file' file: %s", err)
+	if _, err := os.Create(TestPath); err != nil {
+		t.Fatalf("Error creating '%s' file: %s", TestPath, err)
 	}
-	defer os.Remove("testdata/file")
+	defer os.Remove(TestPath)
 	time.Sleep(100 * time.Millisecond)
 	if !pkg.IsLoaded() {
 		t.Error("Expected package loaded")


### PR DESCRIPTION
Check function of the Record was testing for
equality with the relative path of the
file to watch but the packages functions
use the absolute path.
Therefore the module wasn't getting loaded
and the test was failing.