### PR TITLE
Fix data races in packages tests

### DIFF
--- a/packages/watcher_test.go
+++ b/packages/watcher_test.go
@@ -6,9 +6,9 @@ package packages
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
-	"path/filepath"
 )
 
 func TestWatchDir(t *testing.T) {


### PR DESCRIPTION
Added channel to watcher structure so that
the watcher.Close function can safely wait
until the goroutine is done and avoid data
races that could occur with just the mutex locks.