### PR TITLE
Fix errors in packages tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
+# The kqueue tag is to make the rjeczalik/fsnotify package
+# use the kqueue backend instead of FSevents in OSX/macOS.
+TAGS:=-tags kqueue
+
 precommit: fmt license test
 
 test:
-	@go test -race $$(go list ./... | grep -v vendor)
+	@go test -race $(TAGS) $$(go list ./... | grep -v vendor)
 fmt:
 	@go fmt $$(go list ./... | grep -v vendor)
 license:
 	@go run $(GOPATH)/src/github.com/limetext/tasks/gen_license.go
 fast_test:
-	@go test $$(go list ./... | grep -v vendor)
+	@go test $(TAGS) $$(go list ./... | grep -v vendor)
 
 check_fmt:
 ifneq ($(shell gofmt -l ./ | grep -v vendor | grep -v testdata),)

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,13 @@
-# The kqueue tag is to make the rjeczalik/fsnotify package
-# use the kqueue backend instead of FSevents in OSX/macOS.
-OS?=$(shell uname -s)
-ifeq ($(OS),Darwin)
-	TAGS:=-tags kqueue
-endif
-
 precommit: fmt license test
 
 test:
-	@go test -race $(TAGS) $$(go list ./... | grep -v vendor)
+	@go test -race $$(go list ./... | grep -v vendor)
 fmt:
 	@go fmt $$(go list ./... | grep -v vendor)
 license:
 	@go run $(GOPATH)/src/github.com/limetext/tasks/gen_license.go
 fast_test:
-	@go test $(TAGS) $$(go list ./... | grep -v vendor)
+	@go test $$(go list ./... | grep -v vendor)
 
 check_fmt:
 ifneq ($(shell gofmt -l ./ | grep -v vendor | grep -v testdata),)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # The kqueue tag is to make the rjeczalik/fsnotify package
 # use the kqueue backend instead of FSevents in OSX/macOS.
-TAGS:=-tags kqueue
+OS?=$(shell uname -s)
+ifeq ($(OS),Darwin)
+	TAGS:=-tags kqueue
+endif
 
 precommit: fmt license test
 

--- a/packages/json_test.go
+++ b/packages/json_test.go
@@ -21,7 +21,7 @@ func TestLoadUnLoadJSON(t *testing.T) {
 	if j.err != nil {
 		t.Fatalf("Error on loading json %s: %s", j.Name(), j.err)
 	}
-	if got, exp := set.Get("font_face").(string), "Monospace"; got != exp {
+	if got, exp := set.String("font_face"), "Monospace"; got != exp {
 		t.Errorf("Expected font_face %s, but got %s", exp, got)
 	}
 
@@ -53,7 +53,7 @@ func TestWatch(t *testing.T) {
 		t.Fatalf("Error writing to file %s: %s", testFile, err)
 	}
 	time.Sleep(100 * time.Millisecond)
-	if got, exp := set.Get("font_face").(string), "test"; got != exp {
+	if got, exp := set.String("font_face"), "test"; got != exp {
 		t.Errorf("Expected font_face %s, but got %s", exp, got)
 	}
 
@@ -71,7 +71,7 @@ func TestWatch(t *testing.T) {
 		t.Fatalf("Error writing to file %s: %s", testFile, err)
 	}
 	time.Sleep(100 * time.Millisecond)
-	if got, exp := set.Get("font_face").(string), "Monospace"; got != exp {
+	if got, exp := set.String("font_face"), "Monospace"; got != exp {
 		t.Errorf("Expected font_face %s, but got %s", exp, got)
 	}
 }

--- a/packages/json_test.go
+++ b/packages/json_test.go
@@ -70,7 +70,7 @@ func TestWatch(t *testing.T) {
 	if err := ioutil.WriteFile(testFile, data, 0644); err != nil {
 		t.Fatalf("Error writing to file %s: %s", testFile, err)
 	}
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 	if got, exp := set.Get("font_face").(string), "Monospace"; got != exp {
 		t.Errorf("Expected font_face %s, but got %s", exp, got)
 	}

--- a/packages/json_test.go
+++ b/packages/json_test.go
@@ -70,7 +70,7 @@ func TestWatch(t *testing.T) {
 	if err := ioutil.WriteFile(testFile, data, 0644); err != nil {
 		t.Fatalf("Error writing to file %s: %s", testFile, err)
 	}
-	time.Sleep(1000 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	if got, exp := set.String("font_face"), "Monospace"; got != exp {
 		t.Errorf("Expected font_face %s, but got %s", exp, got)
 	}

--- a/packages/json_test.go
+++ b/packages/json_test.go
@@ -70,7 +70,7 @@ func TestWatch(t *testing.T) {
 	if err := ioutil.WriteFile(testFile, data, 0644); err != nil {
 		t.Fatalf("Error writing to file %s: %s", testFile, err)
 	}
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 	if got, exp := set.String("font_face"), "Monospace"; got != exp {
 		t.Errorf("Expected font_face %s, but got %s", exp, got)
 	}

--- a/packages/json_test.go
+++ b/packages/json_test.go
@@ -70,7 +70,7 @@ func TestWatch(t *testing.T) {
 	if err := ioutil.WriteFile(testFile, data, 0644); err != nil {
 		t.Fatalf("Error writing to file %s: %s", testFile, err)
 	}
-	time.Sleep(1000 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	if got, exp := set.Get("font_face").(string), "Monospace"; got != exp {
 		t.Errorf("Expected font_face %s, but got %s", exp, got)
 	}

--- a/packages/watcher_test.go
+++ b/packages/watcher_test.go
@@ -6,9 +6,9 @@ package packages
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
-	"path/filepath"
 )
 
 func TestWatchDir(t *testing.T) {

--- a/packages/watcher_test.go
+++ b/packages/watcher_test.go
@@ -13,24 +13,24 @@ import (
 
 func TestWatchDir(t *testing.T) {
 	// The backend libraries expect absolute paths
-	TestPath, TestPathErr := filepath.Abs("testdata/file")
+	testPath, testPathErr := filepath.Abs("testdata/file")
 
-	if TestPathErr != nil {
-		t.Fatalf("Couldn't get absolute path for testdata/file: %s", TestPathErr)
+	if testPathErr != nil {
+		t.Fatalf("Couldn't get absolute path for testdata/file: %s", testPathErr)
 	}
 
-	pkg := &dummyPackage{path: TestPath}
-	rec := &Record{func(s string) bool { return s == TestPath },
+	pkg := &dummyPackage{path: testPath}
+	rec := &Record{func(s string) bool { return s == testPath },
 		func(s string) Package { return pkg }}
 
 	Register(rec)
 	defer Unregister(rec)
-	watchDir(filepath.Dir(TestPath))
+	watchDir(filepath.Dir(testPath))
 
-	if _, err := os.Create(TestPath); err != nil {
-		t.Fatalf("Error creating '%s' file: %s", TestPath, err)
+	if _, err := os.Create(testPath); err != nil {
+		t.Fatalf("Error creating '%s' file: %s", testPath, err)
 	}
-	defer os.Remove(TestPath)
+	defer os.Remove(testPath)
 	time.Sleep(100 * time.Millisecond)
 	if !pkg.IsLoaded() {
 		t.Error("Expected package loaded")

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -201,10 +201,15 @@ func (w *Watcher) removeWatch(name string) error {
 	// TODO: notify.Stop(w.fsEvent) would stop ALL watchers
 	// What to do?
 	// fmt.Println("TODO: removeWatch ", name)
-
+	notify.Stop(w.fsEvent)
 	w.watchers = util.Remove(w.watchers, name)
 	if util.Exists(w.dirs, name) {
 		w.removeDir(name)
+	}
+	for watchPath := range w.watched {
+		if err := notify.Watch(watchPath, w.fsEvent, notify.All); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -27,6 +27,7 @@ type (
 		watched  map[string][]interface{}
 		watchers []string // paths we created watcher on
 		dirs     []string // dirs we are watching
+		done     chan bool
 	}
 
 	// Called on file change directories won't recieve this callback
@@ -56,6 +57,7 @@ func NewWatcher() (*Watcher, error) {
 	w.watched = make(map[string][]interface{})
 	w.watchers = make([]string, 0)
 	w.dirs = make([]string, 0)
+	w.done = make(chan bool)
 	go w.observe()
 
 	return w, nil
@@ -64,6 +66,8 @@ func NewWatcher() (*Watcher, error) {
 func (w *Watcher) Close() {
 	notify.Stop(w.fsEvent)
 	close(w.fsEvent)
+	<-w.done
+	close(w.done)
 	w.watched = nil
 	w.watchers = nil
 	w.dirs = nil
@@ -81,6 +85,10 @@ func (w *Watcher) Watch(name string, cb interface{}) error {
 	log.Finest("Watch(%s)", name)
 	fi, err := os.Stat(name)
 	isDir := err == nil && fi.IsDir()
+
+	if isDir {
+		w.flushDir(name)
+	}
 	// If the file doesn't exist currently we will add watcher for file
 	// directory and look for create event inside the directory
 	if os.IsNotExist(err) {
@@ -110,9 +118,6 @@ func (w *Watcher) Watch(name string, cb interface{}) error {
 	}
 	if err := w.watch(name, isDir); err != nil {
 		return err
-	}
-	if isDir {
-		w.flushDir(name)
 	}
 	return nil
 }
@@ -238,6 +243,7 @@ func (w *Watcher) observe() {
 		select {
 		case ev, ok := <-w.fsEvent:
 			if !ok {
+				w.done <- true
 				return
 			}
 			func() {

--- a/window_test.go
+++ b/window_test.go
@@ -186,9 +186,12 @@ func TestOpenProject(t *testing.T) {
 	w := GetEditor().NewWindow()
 	defer w.Close()
 
-	p := w.OpenProject("testdata/project")
-	if got, exp := p.FileName(), abs("testdata/project"); got != exp {
-		t.Errorf("Expected project file name %s, but got %s", exp, got)
+	if p := w.OpenProject("testdata/project"); p != nil {
+		if got, exp := p.FileName(), abs("testdata/project"); got != exp {
+			t.Errorf("Expected project file name %s, but got %s", exp, got)
+		}
+	} else {
+		t.Errorf("OpenProject failed. Project is nil")
 	}
 }
 


### PR DESCRIPTION
[Linux/macOS] Fix data races:
Added channel to watcher structure so that
the watcher.Close function can safely wait
until the goroutine is done and avoid data
races that could occur with just the mutex locks.

[macOS] Fix json_test and watcher_test in packages:
The way FSEvents handles events we need to use the
flushDir function or the notify framework won't
generate events for files if the directory had already
files watched inside.
The flushDir was being called at the end of the Watch
method and therefore it wasn't executing in some cases
where the method was returning before the call.