### PR TITLE
Fix packages tests

### DIFF
--- a/packages/watcher_test.go
+++ b/packages/watcher_test.go
@@ -31,7 +31,7 @@ func TestWatchDir(t *testing.T) {
 		t.Fatalf("Error creating '%s' file: %s", testPath, err)
 	}
 	defer os.Remove(testPath)
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 	if !pkg.IsLoaded() {
 		t.Error("Expected package loaded")
 	}

--- a/packages/watcher_test.go
+++ b/packages/watcher_test.go
@@ -6,31 +6,31 @@ package packages
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
-	"path/filepath"
 )
 
 func TestWatchDir(t *testing.T) {
 	// The backend libraries expect absolute paths
-	TestPath, TestPathErr := filepath.Abs("testdata/file")
+	testPath, testPathErr := filepath.Abs("testdata/file")
 
-	if TestPathErr != nil {
-		t.Fatalf("Couldn't get absolute path for testdata/file: %s", TestPathErr)
+	if testPathErr != nil {
+		t.Fatalf("Couldn't get absolute path for testdata/file: %s", testPathErr)
 	}
 
-	pkg := &dummyPackage{path: TestPath}
-	rec := &Record{func(s string) bool { return s == TestPath },
+	pkg := &dummyPackage{path: testPath}
+	rec := &Record{func(s string) bool { return s == testPath },
 		func(s string) Package { return pkg }}
 
 	Register(rec)
 	defer Unregister(rec)
-	watchDir(filepath.Dir(TestPath))
+	watchDir(filepath.Dir(testPath))
 
-	if _, err := os.Create(TestPath); err != nil {
-		t.Fatalf("Error creating '%s' file: %s", TestPath, err)
+	if _, err := os.Create(testPath); err != nil {
+		t.Fatalf("Error creating '%s' file: %s", testPath, err)
 	}
-	defer os.Remove(TestPath)
+	defer os.Remove(testPath)
 	time.Sleep(100 * time.Millisecond)
 	if !pkg.IsLoaded() {
 		t.Error("Expected package loaded")

--- a/window_test.go
+++ b/window_test.go
@@ -186,9 +186,12 @@ func TestOpenProject(t *testing.T) {
 	w := GetEditor().NewWindow()
 	defer w.Close()
 
-	p := w.OpenProject("testdata/project")
-	if got, exp := p.FileName(), abs("testdata/project"); got != exp {
-		t.Errorf("Expected project file name %s, but got %s", exp, got)
+	if p := w.OpenProject("testdata/project"); p != nil {
+		if got, exp := p.FileName(), abs("testdata/project"); got != exp {
+			t.Errorf("Expected project file name %s, but got %s", exp, got)
+		}
+	} else {
+		t.Errorf("OpenProject failed. Project is nil")
 	}
 }
 


### PR DESCRIPTION
[Linux/macOS] Fix data races:
Move the denitialization of the watcher to when
the fsEvents channel is stopped.

[all] Fix error handling of TestOpenProject:
If the result of w.OpenProject was nil. The test
was exploding